### PR TITLE
chore(deps): migrate to shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,60 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-      "config:recommended",
-      ":dependencyDashboard",
-      ":disableRateLimiting",
-      ":timezone(America/Los_Angeles)",
-      ":semanticCommits"
-    ],
-  "labels": [
-    "renovate"
-  ],
-  "assignees": [
-    "jacaudi"
-  ],
-  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
-    "suppressNotifications": [
-      "prEditedNotification",
-      "prIgnoreNotification"
-    ],
-  "postUpdateOptions": [
-    "gomodTidy"
+    "github>jacaudi/renovate-config:base",
+    "github>jacaudi/renovate-config:go",
+    "github>jacaudi/renovate-config:helm",
+    "github>jacaudi/renovate-config:automerge"
   ],
   "packageRules": [
-    {
-      "description": "Group all GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "automerge": false
-    },
-    {
-      "description": "Auto-merge patch updates after stability period",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Group Docker base images",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["alpine"],
-      "groupName": "Docker base images",
-      "automerge": false
-    },
-    {
-      "description": "Group Helm dependencies",
-      "matchManagers": ["helmv3"],
-      "matchPackageNames": ["common"],
-      "groupName": "Helm dependencies",
-      "automerge": false
-    },
     {
       "description": "Track container images in values.yaml",
       "matchManagers": ["helm-values"],
       "matchPackageNames": ["ghcr.io/kiwix/kiwix-serve", "ghcr.io/jacaudi/kiwix-downloader"],
-      "groupName": "Container images",
-      "automerge": false
+      "groupName": "Container images"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Use shared presets from `jacaudi/renovate-config`
- Keep repo-specific container image tracking rule

## Presets Used
- `base` - Common settings, GitHub Actions grouping
- `go` - Go mod tidy
- `helm` - Helm chart grouping
- `automerge` - Auto-merge patch updates after 3 days

Generated with [Claude Code](https://claude.com/claude-code)